### PR TITLE
Info message when running BrainGlobe Registration plugin with no atlas installed

### DIFF
--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -181,7 +181,6 @@ class RegistrationWidget(CollapsibleWidgetContainer):
             show_info(
                 "No atlas installed. Please download atlas(es) from https://github.com/brainglobe/brainglobe-atlasapi"
             )
-            return
 
         def check_atlas_installed(self):
             if len(self._available_atlases) == 1:

--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -179,7 +179,7 @@ class RegistrationWidget(CollapsibleWidgetContainer):
 
         if len(self._available_atlases) == 1:
             show_info(
-                "No atlas installed. Please download atlas(es) from https://github.com/brainglobe/brainglobe-atlasapi"
+                "No atlases available. Please download atlas(es) with brainglobe-atlasapi (https://github.com/brainglobe/brainglobe-atlasapi) or brainrender-napari (https://brainglobe.info/tutorials/manage-atlases-in-GUI.html)"
             )
 
         def check_atlas_installed(self):

--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -21,13 +21,10 @@ from brainglobe_utils.qtpy.collapsible_widget import CollapsibleWidgetContainer
 from brainglobe_utils.qtpy.logo import header_widget
 from dask_image.ndinterp import affine_transform as dask_affine_transform
 from napari.qt.threading import thread_worker
-from napari.utils.notifications import show_error
+from napari.utils.notifications import show_error, show_info
 from napari.viewer import Viewer
 from pytransform3d.rotations import active_matrix_from_angle
-from qtpy.QtWidgets import (
-    QPushButton,
-    QTabWidget,
-)
+from qtpy.QtWidgets import QMessageBox, QPushButton, QTabWidget
 from skimage.segmentation import find_boundaries
 from skimage.transform import rescale
 
@@ -179,6 +176,26 @@ class RegistrationWidget(CollapsibleWidgetContainer):
         self.add_widget(self.run_button, collapsible=False)
 
         self.layout().itemAt(1).widget().collapse(animate=False)
+
+        if len(self._available_atlases) == 1:
+            show_info(
+                "No atlas installed. Please download atlas(es) from https://github.com/brainglobe/brainglobe-atlasapi"
+            )
+            return
+
+        def check_atlas_installed(self):
+            if len(self._available_atlases) == 1:
+                msg = QMessageBox()
+                msg.setIcon(QMessageBox.Information)
+                msg.setText(
+                    "No atlas installed. Please download atlas(es) from https://github.com/brainglobe/brainglobe-atlasapi"
+                )
+                msg.setWindowTitle("Information")
+                msg.setStandardButtons(QMessageBox.Ok)
+                msg.exec_()
+                return
+
+        check_atlas_installed(self)
 
     def _on_atlas_dropdown_index_changed(self, index):
         # Hacky way of having an empty first dropdown

--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -21,10 +21,10 @@ from brainglobe_utils.qtpy.collapsible_widget import CollapsibleWidgetContainer
 from brainglobe_utils.qtpy.logo import header_widget
 from dask_image.ndinterp import affine_transform as dask_affine_transform
 from napari.qt.threading import thread_worker
-from napari.utils.notifications import show_error, show_info
+from napari.utils.notifications import show_error
 from napari.viewer import Viewer
 from pytransform3d.rotations import active_matrix_from_angle
-from qtpy.QtWidgets import QMessageBox, QPushButton, QTabWidget
+from qtpy.QtWidgets import QPushButton, QTabWidget
 from skimage.segmentation import find_boundaries
 from skimage.transform import rescale
 
@@ -32,6 +32,7 @@ from brainglobe_registration.elastix.register import run_registration
 from brainglobe_registration.utils.utils import (
     adjust_napari_image_layer,
     calculate_rotated_bounding_box,
+    check_atlas_installed,
     find_layer_index,
     get_image_layer_names,
     open_parameter_file,
@@ -177,25 +178,7 @@ class RegistrationWidget(CollapsibleWidgetContainer):
 
         self.layout().itemAt(1).widget().collapse(animate=False)
 
-        if len(self._available_atlases) == 1:
-            show_info(
-                "No atlases available. Please download atlas(es) with brainglobe-atlasapi (https://github.com/brainglobe/brainglobe-atlasapi) or brainrender-napari (https://brainglobe.info/tutorials/manage-atlases-in-GUI.html)"
-            )
-
-        def check_atlas_installed(self):
-            if len(self._available_atlases) == 1:
-                msg = QMessageBox()
-                msg.setIcon(QMessageBox.Information)
-                msg.setTextFormat(Qt.RichText)
-                msg.setText(
-                    "No atlases available. Please download atlas(es) using <a href='https://github.com/brainglobe/brainglobe-atlasapi'>brainglobe-atlasapi</a> or <a href='https://brainglobe.info/tutorials/manage-atlases-in-GUI.html'>brainrender-napari</a>"
-                )
-                msg.setWindowTitle("Information")
-                msg.setStandardButtons(QMessageBox.Ok)
-                msg.exec_()
-                return
-
-        check_atlas_installed(self)
+        check_atlas_installed()
 
     def _on_atlas_dropdown_index_changed(self, index):
         # Hacky way of having an empty first dropdown

--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -186,8 +186,9 @@ class RegistrationWidget(CollapsibleWidgetContainer):
             if len(self._available_atlases) == 1:
                 msg = QMessageBox()
                 msg.setIcon(QMessageBox.Information)
+                msg.setTextFormat(Qt.RichText)
                 msg.setText(
-                    "No atlas installed. Please download atlas(es) from https://github.com/brainglobe/brainglobe-atlasapi"
+                    "No atlases available. Please download atlas(es) using <a href='https://github.com/brainglobe/brainglobe-atlasapi'>brainglobe-atlasapi</a> or <a href='https://brainglobe.info/tutorials/manage-atlases-in-GUI.html'>brainrender-napari</a>"
                 )
                 msg.setWindowTitle("Information")
                 msg.setStandardButtons(QMessageBox.Ok)

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -162,7 +162,7 @@ def calculate_rotated_bounding_box(
 
 def check_atlas_installed():
     available_atlases = get_downloaded_atlases()
-    if len(available_atlases) == 1:
+    if len(available_atlases) == 0:
         show_info(
             "No atlases available. Please download atlas(es) with "
             "brainglobe-atlasapi (https://github.com/brainglobe/brain"

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -6,7 +6,6 @@ import numpy as np
 import numpy.typing as npt
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
 from brainglobe_utils.qtpy.dialog import display_info
-from napari.utils.notifications import show_info
 from pytransform3d.rotations import active_matrix_from_angle
 from qtpy.QtWidgets import QWidget
 

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -7,7 +7,6 @@ import numpy.typing as npt
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
 from brainglobe_utils.qtpy.dialog import display_info
 from pytransform3d.rotations import active_matrix_from_angle
-from qtpy.QtWidgets import QWidget
 
 
 def adjust_napari_image_layer(

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -163,12 +163,6 @@ def calculate_rotated_bounding_box(
 def check_atlas_installed():
     available_atlases = get_downloaded_atlases()
     if len(available_atlases) == 0:
-        show_info(
-            "No atlases available. Please download atlas(es) with "
-            "brainglobe-atlasapi (https://github.com/brainglobe/brain"
-            "globe-atlasapi) or brainrender-napari (https://brainglobe.info"
-            "/tutorials/manage-atlases-in-GUI.html)"
-        )
         display_info(
             widget=QWidget(),
             title="Information",

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -4,7 +4,11 @@ from typing import Dict, List, Tuple
 import napari
 import numpy as np
 import numpy.typing as npt
+from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
+from brainglobe_utils.qtpy.dialog import display_info
+from napari.utils.notifications import show_info
 from pytransform3d.rotations import active_matrix_from_angle
+from qtpy.QtWidgets import QWidget
 
 
 def adjust_napari_image_layer(
@@ -154,3 +158,23 @@ def calculate_rotated_bounding_box(
         int(np.round(max_corner[1] - min_corner[1])),
         int(np.round(max_corner[2] - min_corner[2])),
     )
+
+
+def check_atlas_installed():
+    available_atlases = ["------"] + get_downloaded_atlases()
+    if len(available_atlases) == 1:
+        show_info(
+            "No atlases available. Please download atlas(es) with "
+            "brainglobe-atlasapi (https://github.com/brainglobe/brain"
+            "globe-atlasapi) or brainrender-napari (https://brainglobe.info"
+            "/tutorials/manage-atlases-in-GUI.html)"
+        )
+        display_info(
+            widget=QWidget(),
+            title="Information",
+            message="No atlases available. Please download atlas(es) "
+            "using <a href='https://github.com/brainglobe/brainglobe-at"
+            "lasapi'>brainglobe-atlasapi</a> or <a href='https://brain"
+            "globe.info/tutorials/manage-atlases-in-GUI.html'>brainrend"
+            "er-napari</a>",
+        )

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -161,7 +161,7 @@ def calculate_rotated_bounding_box(
 
 
 def check_atlas_installed():
-    available_atlases = ["------"] + get_downloaded_atlases()
+    available_atlases = get_downloaded_atlases()
     if len(available_atlases) == 1:
         show_info(
             "No atlases available. Please download atlas(es) with "

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
 from brainglobe_utils.qtpy.dialog import display_info
 from pytransform3d.rotations import active_matrix_from_angle
+from qtpy.QtWidgets import QWidget
 
 
 def adjust_napari_image_layer(
@@ -159,10 +160,14 @@ def calculate_rotated_bounding_box(
 
 
 def check_atlas_installed():
+    """
+    Function checks if user has any atlases installed. If not, message box
+    appears in napari, directing user to download atlases via attached links.
+    """
     available_atlases = get_downloaded_atlases()
     if len(available_atlases) == 0:
         display_info(
-            widget=parent_widget,
+            widget=QWidget(),
             title="Information",
             message="No atlases available. Please download atlas(es) "
             "using <a href='https://brainglobe.info/documentation/"

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -166,8 +166,8 @@ def check_atlas_installed():
             widget=QWidget(),
             title="Information",
             message="No atlases available. Please download atlas(es) "
-            "using <a href='https://github.com/brainglobe/brainglobe-at"
-            "lasapi'>brainglobe-atlasapi</a> or <a href='https://brain"
-            "globe.info/tutorials/manage-atlases-in-GUI.html'>brainrend"
-            "er-napari</a>",
+            "using <a href='https://brainglobe.info/documentation/"
+            "brainglobe-atlasapi/usage/command-line-interface.html'>"
+            "brainglobe-atlasapi</a> or <a href='https://brainglobe.info/"
+            "tutorials/manage-atlases-in-GUI.html'>brainrender-napari</a>",
         )

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -163,7 +163,7 @@ def check_atlas_installed():
     available_atlases = get_downloaded_atlases()
     if len(available_atlases) == 0:
         display_info(
-            widget=QWidget(),
+            widget=parent_widget,
             title="Information",
             message="No atlases available. Please download atlas(es) "
             "using <a href='https://brainglobe.info/documentation/"

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -167,7 +167,7 @@ def check_atlas_installed(parent_widget: QWidget):
     available_atlases = get_downloaded_atlases()
     if len(available_atlases) == 0:
         display_info(
-            widget=QWidget(),
+            widget=parent_widget,
             title="Information",
             message="No atlases available. Please download atlas(es) "
             "using <a href='https://brainglobe.info/documentation/"


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

If user has no atlases installed, this widget informs user that they need to install atlas(es) before they are able to use BrainGlobe Registration plugin.

**What does this PR do?**

If no atlases installed:
    - Info message in terminal: "No atlas installed. Please download atlas(es) from https://github.com/brainglobe/brainglobe-atlasapi"
    - Message box appears in Napari GUI with same message


![image](https://github.com/user-attachments/assets/0fe09925-aa67-428e-aaec-1761c5668ab6)


![image](https://github.com/user-attachments/assets/17cd45d2-2c42-45e1-ab3a-a60a3ed33cb5)


## References

Please reference any existing issues/PRs that relate to this PR.

Issue #15 

## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

- No atlases downloaded - info messages appear as expected
- Atlases downloaded - info messages do not appear (as expected)
- Deleted all atlases - info messages appear as expected

## Is this a breaking change?

If this PR breaks any existing functionality, please explain how and why.

N/A

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
