### PR TITLE
Fix sample data loading to be independent of current working directory

### DIFF
--- a/brainglobe_registration/napari.yaml
+++ b/brainglobe_registration/napari.yaml
@@ -5,10 +5,13 @@ contributions:
     - id: brainglobe-registration.make_registration_widget
       python_name: brainglobe_registration.registration_widget:RegistrationWidget
       title: BrainGlobe Registration
+    - id: brainglobe-registration.load_sample
+      python_name: brainglobe_registration.sample_data:load_sample_data
+      title: Sample Data
   sample_data:
-    - key: example
-      display_name: Sample Brain Slice
-      uri: src/brainglobe_registration/resources/sample_hipp.tif
+    - command: brainglobe-registration.load_sample
+      display_name: Sample Data
+      key: example
   widgets:
     - command: brainglobe-registration.make_registration_widget
       display_name: BrainGlobe Registration

--- a/brainglobe_registration/sample_data.py
+++ b/brainglobe_registration/sample_data.py
@@ -1,0 +1,21 @@
+from importlib.resources import files
+from typing import List
+
+from napari.types import LayerData
+from tifffile import imread
+
+
+def load_sample_data() -> List[LayerData]:
+    """
+    Load the sample data.
+
+    Returns
+    -------
+    List[LayerData]
+        The sample data.
+    """
+    path = str(
+        files("brainglobe_registration").joinpath("resources/sample_hipp.tif")
+    )
+
+    return [(imread(path), {"name": "Sample Data"})]


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Currently, the sample data could only be loaded if `napari` was started in the package directory. Otherwise, you'd get a file not found error.

**What does this PR do?**
Allows the sample data to be opened regardless of the working directory.

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?
Tested locally by visual inspection.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?
No.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
