### PR TITLE
Mark 'Advanced Settings' as optional

### DIFF
--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -175,7 +175,9 @@ class RegistrationWidget(CollapsibleWidgetContainer):
             self.parameters_tab.addTab(new_tab, transform_type)
             self.parameter_setting_tabs_lists.append(new_tab)
 
-        self.add_widget(self.parameters_tab, widget_title="Advanced Settings")
+        self.add_widget(
+            self.parameters_tab, widget_title="Advanced Settings (optional)"
+        )
         self.add_widget(self.run_button, collapsible=False)
 
         self.layout().itemAt(1).widget().collapse(animate=False)


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Clarifies to user that the Advanced Settings on the brainglobe-registration UI is an optional setting and that it is possible to run registration without it.

**What does this PR do?**

Changes label from "Advanced Settings" to "Advanced Settings (optional)"


![image](https://github.com/user-attachments/assets/08f19f82-4e88-42c5-b2ef-c27baf621f81)


## References

Please reference any existing issues/PRs that relate to this PR.

#27 

## How has this PR been tested?

Tested by running the code as this is only a change to the widget title itself.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://brainglobe.info/community/developers/index.html#to-improve-the-documentation) for details.

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
