### PR TITLE
Communicate napari layer deletions appropriately to the plugin

### DIFF
--- a/brainglobe_registration/widgets/select_images_view.py
+++ b/brainglobe_registration/widgets/select_images_view.py
@@ -122,5 +122,9 @@ class SelectImagesView(QWidget):
             self.available_sample_dropdown.currentIndex()
         )
 
+    def reset_atlas_combobox(self):
+        if self.available_atlas_dropdown is not None:
+            self.available_atlas_dropdown.setCurrentIndex(0)
+
     def _on_sample_popup_about_to_show(self):
         self.sample_image_popup_about_to_show.emit()


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

Please fill out as much of this template as you can, but if you have any problems or questions, just leave a comment and we will help out :)

## Description

**What is this PR**

- [x] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

"Currently, if a user deletes the atlas or moving image layer the plugin goes into undefined behaviour and will probably throw index out of bounds errors.

Need to make sure that layer deletions are communicated appropriately and the plugin can handle restarting the entire workflow without having to restart the plugin."

[#44]

**What does this PR do?**

Bug Fixes:

- Deleting moving image sets self._moving_image and self._moving_image_data_backup to None.
- Deleting moving image removes it from the sample image dropdown menu and the next item in dropdown menu (equivalent to list of layers) is automatically selected as moving image.
- Deleting either one of the atlas layers (Reference or Annotations) automatically deletes the other layer, and clears any class attributes related to the atlas, sets self._atlas back to None, and sets the index for the atlas selection combobox back to 0.

Additional Features:

- If user deletes atlas and tries to re-run registration with atlas selection combobox index == 0, message box appears:

![image](https://github.com/user-attachments/assets/0376cfb4-b560-4108-b3e0-1cc8834b0b67)


- If user deletes moving image and the new moving image is automatically set to the atlas layer (i.e. user forgets to change this / add a new moving image layer), message box appears:

![image](https://github.com/user-attachments/assets/c8ce7217-214c-48da-b561-ee94d641bf57)



## References

Issue #44 

## How has this PR been tested?

- Tested by deleting the moving layer only --> works as expected.
- Tested by deleting the atlas layers only --> works as expected.
- Tested by deleting both layers --> works as expected.

Essentially user is able to delete layers as required and restart entire workflow without restarting plugin.


## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

N/A

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
