### PR TITLE
Name sample data

### DIFF
--- a/brainglobe_registration/napari.yaml
+++ b/brainglobe_registration/napari.yaml
@@ -10,7 +10,7 @@ contributions:
       title: Sample Data
   sample_data:
     - command: brainglobe-registration.load_sample
-      display_name: Sample Data
+      display_name: 2D coronal mouse brain section
       key: example
   widgets:
     - command: brainglobe-registration.make_registration_widget

--- a/brainglobe_registration/sample_data.py
+++ b/brainglobe_registration/sample_data.py
@@ -18,4 +18,4 @@ def load_sample_data() -> List[LayerData]:
         files("brainglobe_registration").joinpath("resources/sample_hipp.tif")
     )
 
-    return [(imread(path), {"name": "Sample Data"})]
+    return [(imread(path), {"name": "2D coronal mouse brain section"})]


### PR DESCRIPTION
The current name "Sample data" doesn't tell the user what the sample image is. Also at some point, there will need to be >1 sample image, (3D etc). This PR just gives the sample data a more informative title. 