### PR TITLE
Import Qt elements from qt-niu

### DIFF
--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -18,8 +18,6 @@ import numpy as np
 import numpy.typing as npt
 from brainglobe_atlasapi import BrainGlobeAtlas
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
-from brainglobe_utils.qtpy.collapsible_widget import CollapsibleWidgetContainer
-from brainglobe_utils.qtpy.dialog import display_info
 from brainglobe_utils.qtpy.logo import header_widget
 from dask_image.ndinterp import affine_transform as dask_affine_transform
 from napari.qt.threading import thread_worker
@@ -27,6 +25,8 @@ from napari.utils.events import Event
 from napari.utils.notifications import show_error
 from napari.viewer import Viewer
 from pytransform3d.rotations import active_matrix_from_angle
+from qt_niu.collapsible_widget import CollapsibleWidgetContainer
+from qt_niu.dialog import display_info
 from qtpy.QtWidgets import (
     QCheckBox,
     QFileDialog,

--- a/brainglobe_registration/utils/utils.py
+++ b/brainglobe_registration/utils/utils.py
@@ -9,8 +9,8 @@ import numpy.typing as npt
 import pandas as pd
 from brainglobe_atlasapi import BrainGlobeAtlas
 from brainglobe_atlasapi.list_atlases import get_downloaded_atlases
-from brainglobe_utils.qtpy.dialog import display_info
 from pytransform3d.rotations import active_matrix_from_angle
+from qt_niu.dialog import display_info
 from qtpy.QtWidgets import QWidget
 from scipy.ndimage import gaussian_filter
 from skimage import morphology

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pandas",
     "pytransform3d",
     "qtpy",
+    "qt-niu"
 ]
 
 [project.urls]


### PR DESCRIPTION
Re-useable Qt elements have been moved from brainglobe-utils to [qt-niu](https://github.com/neuroinformatics-unit/qt-niu). This PR changes the imports accordingly. 