### PR TITLE
Add optical flow functions and tests

### DIFF
--- a/brainglobe_registration/optical_flow.py
+++ b/brainglobe_registration/optical_flow.py
@@ -1,13 +1,11 @@
 import numpy as np
 import numpy.typing as npt
-from skimage.registration import optical_flow_tvl1, optical_flow_ilk
 from skimage.color import rgb2gray
+from skimage.registration import optical_flow_ilk, optical_flow_tvl1
 
 
 def compute_optical_flow_skimage(
-    image1: npt.NDArray,
-    image2: npt.NDArray,
-    method: str = "tvl1"
+    image1: npt.NDArray, image2: npt.NDArray, method: str = "tvl1"
 ) -> npt.NDArray:
     """
     Compute dense optical flow using skimage.
@@ -46,8 +44,7 @@ def compute_optical_flow_skimage(
 
 
 def compare_deformation_fields(
-    elastix_field: npt.NDArray,
-    optical_flow: npt.NDArray
+    elastix_field: npt.NDArray, optical_flow: npt.NDArray
 ) -> float:
     """
     Compare the elastix deformation field with optical flow field.
@@ -69,7 +66,9 @@ def compare_deformation_fields(
 
     # Resize if shapes don't match
     if elastix_field.shape != optical_flow.shape:
-        raise ValueError("Shape mismatch between elastix and optical flow fields")
+        raise ValueError(
+            "Shape mismatch between elastix and optical flow fields"
+        )
 
     diff = elastix_field - optical_flow
     mse = np.mean(np.square(diff))

--- a/brainglobe_registration/optical_flow.py
+++ b/brainglobe_registration/optical_flow.py
@@ -1,0 +1,76 @@
+import numpy as np
+import numpy.typing as npt
+from skimage.registration import optical_flow_tvl1, optical_flow_ilk
+from skimage.color import rgb2gray
+
+
+def compute_optical_flow_skimage(
+    image1: npt.NDArray,
+    image2: npt.NDArray,
+    method: str = "tvl1"
+) -> npt.NDArray:
+    """
+    Compute dense optical flow using skimage.
+
+    Parameters
+    ----------
+    image1 : npt.NDArray
+        First image (reference).
+    image2 : npt.NDArray
+        Second image (moving).
+    method : str
+        Optical flow method: "tvl1" or "ilk".
+
+    Returns
+    -------
+    flow : npt.NDArray
+        Optical flow (flow_y, flow_x)
+    """
+    # Ensure grayscale
+    if image1.ndim == 3:
+        image1 = rgb2gray(image1)
+    if image2.ndim == 3:
+        image2 = rgb2gray(image2)
+
+    image1 = image1.astype(np.float32)
+    image2 = image2.astype(np.float32)
+
+    if method == "tvl1":
+        flow = optical_flow_tvl1(image1, image2)
+    elif method == "ilk":
+        flow = optical_flow_ilk(image1, image2, radius=5)
+    else:
+        raise ValueError("Unsupported method. Use 'tvl1' or 'ilk'.")
+
+    return flow  # shape: (2, H, W)
+
+
+def compare_deformation_fields(
+    elastix_field: npt.NDArray,
+    optical_flow: npt.NDArray
+) -> float:
+    """
+    Compare the elastix deformation field with optical flow field.
+
+    Parameters
+    ----------
+    elastix_field : npt.NDArray
+        The deformation field from elastix (H, W, 2).
+    optical_flow : npt.NDArray
+        The optical flow from skimage (2, H, W).
+
+    Returns
+    -------
+    float
+        Mean squared error between the fields.
+    """
+    # Convert skimage format (2, H, W) to (H, W, 2)
+    optical_flow = np.moveaxis(optical_flow, 0, -1)
+
+    # Resize if shapes don't match
+    if elastix_field.shape != optical_flow.shape:
+        raise ValueError("Shape mismatch between elastix and optical flow fields")
+
+    diff = elastix_field - optical_flow
+    mse = np.mean(np.square(diff))
+    return mse

--- a/tests/test_optical_flow.py
+++ b/tests/test_optical_flow.py
@@ -1,0 +1,34 @@
+import numpy as np
+from brainglobe_registration.optical_flow import (
+    compute_optical_flow_skimage,
+    compare_deformation_fields
+)
+
+
+def test_compute_optical_flow_2d():
+    # Create two shifted squares
+    img1 = np.zeros((100, 100), dtype=np.float32)
+    img2 = np.zeros_like(img1)
+
+    img1[30:70, 30:70] = 1
+    img2[32:72, 35:75] = 1  # Shifted down and right
+
+    flow = compute_optical_flow_skimage(img1, img2, method="tvl1")
+
+    assert flow.shape == (2, 100, 100)
+    assert np.any(flow != 0), "Flow field should contain non-zero displacement"
+
+
+def test_compare_deformation_fields_2d():
+    shape = (100, 100)
+    dummy_flow = np.zeros((2, *shape), dtype=np.float32)
+    dummy_elastix = np.zeros((*shape, 2), dtype=np.float32)
+
+    # Simulate some known flow
+    dummy_flow[0, 50, 50] = 2  # y
+    dummy_flow[1, 50, 50] = 3  # x
+    dummy_elastix[50, 50, 0] = 2
+    dummy_elastix[50, 50, 1] = 3
+
+    mse = compare_deformation_fields(dummy_elastix, dummy_flow)
+    assert mse < 1e-6, "MSE should be near zero for matching fields"

--- a/tests/test_optical_flow.py
+++ b/tests/test_optical_flow.py
@@ -1,7 +1,8 @@
 import numpy as np
+
 from brainglobe_registration.optical_flow import (
+    compare_deformation_fields,
     compute_optical_flow_skimage,
-    compare_deformation_fields
 )
 
 


### PR DESCRIPTION
## Description

**What is this PR**
- [ ] Bug fix
- [x] Addition of a new feature  
- [ ] Other

**Why is this PR needed?**
The current codebase does not include optical flow-based motion estimation or tools to validate image registration results. 
This PR introduces a way to:
- Compute dense optical flow using `skimage.registration`
- Compare optical flow with elastix-generated deformation fields
- Quantitatively evaluate registration quality using MSE

This adds a simple but valuable tool for benchmarking and alternative validation, especially for 2D datasets.


**What does this PR do?**
- Adds `compute_optical_flow_skimage()` to compute dense 2D optical flow using either`optical_flow_tvl1` or`optical_flow_ilk` from `scikit-image`.
- Adds `compare_deformation_fields()` to compute mean squared error (MSE) between an elastix deformation field and optical flow field.
- Includes unit tests in `tests/test_optical_flow.py`:
  - Validates output shape and non-zero flow
  - Tests comparison on simulated ground truth deformation


## How has this PR been tested?

- Added new unit tests for both optical flow computation and deformation field comparison
- Tests validate shape, content, and MSE calculation
- Verified that the new functionality is isolated and does not modify any existing behavior in the codebase

## Is this a breaking change?

No.  This PR introduces new standalone functionality and does not modify or remove any existing code.


## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)






