### PR TITLE
Add Preprocessing Script to Apply Bilateral Filter On Image Plane

### DIFF
--- a/brainglobe_registration/utils/preprocess.py
+++ b/brainglobe_registration/utils/preprocess.py
@@ -117,11 +117,14 @@ def pseudo_flatfield(img_plane: npt.NDArray, sigma: int = 5):
 
 
 def bilateral_filter(
-        img_plane: npt.NDArray, win_size: int = 5, sd_intensity: float = 0.1, sigma_spatial: float = 15.0
+    img_plane: npt.NDArray,
+    win_size: int = 5,
+    sd_intensity: float = 0.1,
+    sigma_spatial: float = 15.0,
 ) -> npt.NDArray:
     """
-    Implementation of a non-linear and noise-reducing smoothing filter for the image plane 
-    that preserves its edges. The filter smoothes the image by taking weighted averages for 
+    Implementation of a non-linear and noise-reducing smoothing filter for the image plane
+    that preserves its edges. The filter smoothes the image by taking weighted averages for
     each pixel, by taking into account spatial closeness and intensity of nearby pixels.
     This weight can be based on a Gaussian distribution.
 
@@ -132,13 +135,13 @@ def bilateral_filter(
     win_size : int
         Size of each region around pixel to be considered for filtering.
     sigma_intensity : float
-        Gaussian function of the Euclidean distance between two color values 
+        Gaussian function of the Euclidean distance between two color values
         and a certain standard deviation
     sigma_spatial : float
-        Radiometric similarity is measured by the Gaussian function of the 
+        Radiometric similarity is measured by the Gaussian function of the
         Euclidean distance between two color values and a certain standard deviation
     multichannel : boolean
-        False - Grayscale images 
+        False - Grayscale images
         True - Colour Images
 
     Returns
@@ -146,4 +149,10 @@ def bilateral_filter(
     npt.NDArray
         The filtered image
     """
-    return denoise_bilateral(img_plane, win_size=win_size, sigma_color=sd_intensity, sigma_spatial=sigma_spatial, multichannel=False)
+    return denoise_bilateral(
+        img_plane,
+        win_size=win_size,
+        sigma_color=sd_intensity,
+        sigma_spatial=sigma_spatial,
+        multichannel=False,
+    )


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR introduces a preprocessing step to apply a Bilateral Filter to the image plane, reducing the noise while preserving edges, making it useful for improving the accuracy of later image registration workflows.

**What does this PR do?**

This PR implements a bilateral filter to the moving image before registration. The filter helps to denoise the image while maintaining critical anatomical features. The parameters for the filter function can be adjusted as desired, such as the window size considered for filtering each pixel, the intensity and standard deviation for range distance. 

## References

Filter the moving and fixed image prior to registration #50 
https://github.com/brainglobe/brainglobe-registration/issues/50

## How has this PR been tested?

The script has been tested on my local machine using sample images from tests/test_images/

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

A minor mention of the filter can be added.



## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
