### PR TITLE
Pin napari version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "napari>=0.4.18",
+    "napari>=0.4.18,<0.6.0",
     "brainglobe-atlasapi",
     "brainglobe-utils>=0.4.3",
     "dask",


### PR DESCRIPTION
Pinning `napari<0.6.0`. Can't instantiate a label layer from an array of `uint32` dtype in `napari==0.6.0`.