### PR TITLE
Fix crash when running registration with no transform selected

### DIFF
--- a/brainglobe_registration/registration_widget.py
+++ b/brainglobe_registration/registration_widget.py
@@ -577,7 +577,7 @@ class RegistrationWidget(QScrollArea):
         if len(self.transform_selections) == 0:
             display_info(
                 widget=self,
-                title="Warning",
+                title="No Transforms Selected",
                 message="Please select at least one transform "
                 "before clicking 'Run'.",
             )

--- a/tests/test_registration_widget.py
+++ b/tests/test_registration_widget.py
@@ -626,7 +626,7 @@ def test_on_run_button_clicked_no_transform_selected(
 
     mocked_display_info.assert_called_once_with(
         widget=widget,
-        title="Warning",
+        title="No Transforms Selected",
         message="Please select at least one transform before clicking 'Run'.",
     )
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
- Running registration with no transform selected caused ```Elastix``` to receive an empty ```parameter``` map, resulting in a runtime error.

**What does this PR do?**
- Adds a guard in ```_on_run_button_click``` to prevent calling ```run_registration``` when no transforms are selected. The widget now shows a warning and simply exits instead of crashing.

## References
- Fixes #155 

## How has this PR been tested?
- Added a unit test ```(test_on_run_button_clicked_no_transform_selected)``` to cover the new branch.

## Is this a breaking change?
- No.

## Does this PR require an update to the documentation?
- No.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
